### PR TITLE
🔧 Vite config reconfigured to have env variables for the server section

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -22,8 +22,8 @@ export default defineConfig({
     server: {
         cors: true,
         hmr: {
-            host: 'www.homemoviehub.com',
-            protocol: 'https'  // Add this to ensure HTTPS
+            host: process.env.HMR_HOST || 'localhost',
+            protocol: process.env.HMR_PROTOCOL || 'http', // Ensures HTTPS on live, http on local
         },
     },
     build: {


### PR DESCRIPTION
Localhost was not loading properly due to the server config in the vite config file being hardcoded

- Config changed to be env variables and defaulting to localhost if not set