### PR TITLE
🐛 Cover image Size Validation Changes

### DIFF
--- a/app/Http/Controllers/VideoController.php
+++ b/app/Http/Controllers/VideoController.php
@@ -180,7 +180,7 @@ class VideoController extends Controller
             'cover_image' => [
                 'required',
                 File::types(['jpeg', 'png', 'jpg'])
-                    ->max(12 * 1024),
+                    ->max(2048),
             ],
         ]);
 

--- a/app/Services/AvatarService.php
+++ b/app/Services/AvatarService.php
@@ -21,7 +21,7 @@ class AvatarService
             'avatar' => [
                 'required',
                 File::types(['jpeg', 'png', 'jpg'])
-                    ->max(12 * 1024),
+                    ->max(2048),
             ],
         ]);
 


### PR DESCRIPTION
Resolves #36 

CAUSE:

The issue is caused by Heroku having a 2MB size limit for uploads.

FIX:

I decided not to work around this as it would be better to not have an image size more than 2MB anyway to keep data size down, so I did the following:

- Updated validation rules for both cover images and avatar images to match the 2MB
- Added a new test for both the Video and Avatar service tests to check if uploading over 2MB fails validation
