### PR TITLE
🔧 Manually set default app name

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -50,7 +50,7 @@ library.add(
     faSignIn
 )
 
-const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+const appName = import.meta.env.VITE_APP_NAME || 'HomeMovieHub';
 
 createInertiaApp({
     title: (title) => `${title} | ${appName}`,


### PR DESCRIPTION
Resolves #38 

CAUSE:

- VITE_APP_NAME variable missing in Heroku env

FIX:

- Added missing variable in Heroku
- Fixed default name to be HomeMovieHub regardless for now